### PR TITLE
Add WHOA_SYSTEM_WEB support to mutex/lock primitives

### DIFF
--- a/bc/Lock.cpp
+++ b/bc/Lock.cpp
@@ -21,7 +21,7 @@ int32_t Blizzard::Lock::MutexCreate(Blizzard::Lock::Mutex& mutex) {
     InitializeCriticalSection(&mutex);
 
     return 0;
-#elif defined(WHOA_SYSTEM_MAC) || defined(WHOA_SYSTEM_LINUX)
+#elif defined(WHOA_SYSTEM_MAC) || defined(WHOA_SYSTEM_LINUX) || defined(WHOA_SYSTEM_WEB)
     Blizzard::Lock::DoOnce(System_Lock::s_initMutexAttrOnce, System_Lock::InitAttr, nullptr);
 
     auto result = pthread_mutex_init(&mutex, &System_Lock::s_mutexattr);
@@ -36,7 +36,7 @@ int32_t Blizzard::Lock::MutexEnter(Blizzard::Lock::Mutex& mutex) {
     EnterCriticalSection(&mutex);
 
     return 0;
-#elif defined(WHOA_SYSTEM_MAC) || defined(WHOA_SYSTEM_LINUX)
+#elif defined(WHOA_SYSTEM_MAC) || defined(WHOA_SYSTEM_LINUX) || defined(WHOA_SYSTEM_WEB)
     auto result = pthread_mutex_lock(&mutex);
     BLIZZARD_ASSERT(result == 0);
 
@@ -49,7 +49,7 @@ int32_t Blizzard::Lock::MutexLeave(Blizzard::Lock::Mutex& mutex) {
     LeaveCriticalSection(&mutex);
 
     return 0;
-#elif defined(WHOA_SYSTEM_MAC) || defined(WHOA_SYSTEM_LINUX)
+#elif defined(WHOA_SYSTEM_MAC) || defined(WHOA_SYSTEM_LINUX) || defined(WHOA_SYSTEM_WEB)
     auto result = pthread_mutex_unlock(&mutex);
     BLIZZARD_ASSERT(result == 0);
 

--- a/bc/Lock.hpp
+++ b/bc/Lock.hpp
@@ -6,7 +6,7 @@
 
 #if defined(WHOA_SYSTEM_WIN)
 #include <windows.h>
-#elif defined(WHOA_SYSTEM_MAC) || defined(WHOA_SYSTEM_LINUX)
+#elif defined(WHOA_SYSTEM_MAC) || defined(WHOA_SYSTEM_LINUX) || defined(WHOA_SYSTEM_WEB)
 #include <pthread.h>
 #endif
 
@@ -16,7 +16,7 @@ namespace Lock {
 // Types
 #if defined(WHOA_SYSTEM_WIN)
 typedef CRITICAL_SECTION Mutex;
-#elif defined(WHOA_SYSTEM_MAC) || defined(WHOA_SYSTEM_LINUX)
+#elif defined(WHOA_SYSTEM_MAC) || defined(WHOA_SYSTEM_LINUX) || defined(WHOA_SYSTEM_WEB)
 typedef pthread_mutex_t Mutex;
 #endif
 

--- a/bc/system/System_Lock.cpp
+++ b/bc/system/System_Lock.cpp
@@ -1,12 +1,12 @@
 #include "bc/system/System_Lock.hpp"
 
-#if defined(WHOA_SYSTEM_MAC) || defined(WHOA_SYSTEM_LINUX)
+#if defined(WHOA_SYSTEM_MAC) || defined(WHOA_SYSTEM_LINUX) || defined(WHOA_SYSTEM_WEB)
 Blizzard::Lock::DoOnceData Blizzard::System_Lock::s_initMutexAttrOnce;
 Blizzard::System_Lock::MutexAttr Blizzard::System_Lock::s_mutexattr;
 #endif
 
 void Blizzard::System_Lock::InitAttr(void* a1) {
-#if defined(WHOA_SYSTEM_MAC) || defined(WHOA_SYSTEM_LINUX)
+#if defined(WHOA_SYSTEM_MAC) || defined(WHOA_SYSTEM_LINUX) || defined(WHOA_SYSTEM_WEB)
     pthread_mutexattr_init(&System_Lock::s_mutexattr);
     pthread_mutexattr_settype(&System_Lock::s_mutexattr, PTHREAD_MUTEX_RECURSIVE);
 #endif

--- a/bc/system/System_Lock.hpp
+++ b/bc/system/System_Lock.hpp
@@ -3,7 +3,7 @@
 
 #include "bc/Lock.hpp"
 
-#if defined(WHOA_SYSTEM_MAC) || defined(WHOA_SYSTEM_LINUX)
+#if defined(WHOA_SYSTEM_MAC) || defined(WHOA_SYSTEM_LINUX) || defined(WHOA_SYSTEM_WEB)
 #include <pthread.h>
 #endif
 
@@ -11,12 +11,12 @@ namespace Blizzard {
 namespace System_Lock {
 
 // Types
-#if defined(WHOA_SYSTEM_MAC) || defined(WHOA_SYSTEM_LINUX)
+#if defined(WHOA_SYSTEM_MAC) || defined(WHOA_SYSTEM_LINUX) || defined(WHOA_SYSTEM_WEB)
 typedef pthread_mutexattr_t MutexAttr;
 #endif
 
 // Variables
-#if defined(WHOA_SYSTEM_MAC) || defined(WHOA_SYSTEM_LINUX)
+#if defined(WHOA_SYSTEM_MAC) || defined(WHOA_SYSTEM_LINUX) || defined(WHOA_SYSTEM_WEB)
 extern Lock::DoOnceData s_initMutexAttrOnce;
 extern MutexAttr s_mutexattr;
 #endif


### PR DESCRIPTION
Extend pthread-based mutex implementation to web platform by adding WHOA_SYSTEM_WEB alongside MAC and LINUX conditionals.